### PR TITLE
Handle snippet with blank accountid DE-3132

### DIFF
--- a/app/design/frontend/base/default/template/drip/footer_js.phtml
+++ b/app/design/frontend/base/default/template/drip/footer_js.phtml
@@ -1,5 +1,5 @@
 <?php if (Mage::helper('drip_connect')->isModuleActive()) : ?>
-    <?php $accountId = Mage::getStoreConfig('dripconnect_general/api_settings/account_id'); ?>
+    <?php $accountId = Mage::getStoreConfig('dripconnect_general/api_settings/account_id', Mage::app()->getRequest()->getParam('store')); ?>
     <?php if (!empty($accountId)) : ?>
         <!-- Drip -->
         <script type="text/javascript">


### PR DESCRIPTION
https://dripcom.atlassian.net/browse/DE-3132

If the store view has the module disabled, the snippet won't show at all. However, customers sometimes will enable the plugin and not add an account ID. This creates a somewhat confusing situation, where a snippet is added but without the account ID. Instead of doing so, we add an HTML comment to elucidate the situation.

This also fixes a bug where it only looks at the global configuration instead of the store configuration.