### PR TITLE
Skip newsletter event when email invalid DE-3129

### DIFF
--- a/app/code/community/Drip/Connect/Model/Cron/Customers.php
+++ b/app/code/community/Drip/Connect/Model/Cron/Customers.php
@@ -102,7 +102,7 @@ class Drip_Connect_Model_Cron_Customers
             foreach ($collection as $subscriber) {
                 $email = $subscriber->getSubscriberEmail();
                 if (!Mage::helper('drip_connect')->isEmailValid($email)) {
-                    Mage::log("Skipping newsletter subscriber event during sync due to unusable email", Zend_Log::NOTICE);
+                    $this->getLogger()->log("Skipping newsletter subscriber event during sync due to unusable email", Zend_Log::NOTICE);
                     continue;
                 }
 

--- a/app/code/community/Drip/Connect/Model/Observer/Account.php
+++ b/app/code/community/Drip/Connect/Model/Observer/Account.php
@@ -265,7 +265,7 @@ class Drip_Connect_Model_Observer_Account
     {
         $email = $subscriber->getSubscriberEmail();
         if (!Mage::helper('drip_connect')->isEmailValid($email)) {
-            Mage::log("Skipping guest subscriber create due to unusable email", Zend_Log::NOTICE);
+            $this->getLogger()->log("Skipping guest subscriber create due to unusable email", Zend_Log::NOTICE);
             return;
         }
 
@@ -290,7 +290,7 @@ class Drip_Connect_Model_Observer_Account
     {
         $email = $customer->getEmail();
         if (!Mage::helper('drip_connect')->isEmailValid($email)) {
-            Mage::log("Skipping guest subscriber create due to unusable email", Zend_Log::NOTICE);
+            $this->getLogger()->log("Skipping guest subscriber create due to unusable email", Zend_Log::NOTICE);
             return;
         }
 
@@ -434,5 +434,9 @@ class Drip_Connect_Model_Observer_Account
             'country' => $address->getCountry(),
             'phone_number' => $address->getTelephone(),
         );
+    }
+
+    protected function getLogger() {
+        return Mage::helper('drip_connect/logger')->logger();
     }
 }


### PR DESCRIPTION
Newsletter events get sent and rejected with blank and invalid emails. Let's just skip them.