### PR TITLE
Disable product events for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Send `product_variant_id` correctly for all product types
 * Backend: Introduce the beginnings of a thorough Cypress.io based test suite.
 * When a product isn't in any categories, stop sending an array with a single empty string. Send an empty array instead.
+* Disable product event based product syncing since it's very broken for configurable products. Product data is still sent as part of order and cart events.
 
 ## 1.7.5
 

--- a/app/code/community/Drip/Connect/etc/config.xml
+++ b/app/code/community/Drip/Connect/etc/config.xml
@@ -216,6 +216,11 @@
             </adminhtml>
         </routers>
     </admin>
+    <!--
+    This is very broken for configurable products, and we don't have a good way
+    of fixing this in the short term. Disable it in order to not make a mess of
+    data while we work on it. Product data will still be sent as part of order
+    and cart events.
     <adminhtml>
         <events>
             <catalog_product_save_before>
@@ -244,6 +249,7 @@
             </catalog_product_delete_after>
         </events>
     </adminhtml>
+    -->
     <default>
         <dripconnect_general>
             <module_settings>


### PR DESCRIPTION
I attempted to fix the product sync and add `product_variant_id`. Turns out that a simple product event gets fired well before it is associated with a configurable product. So it's tough to do an in-the-moment sync of products. This is also completely broken for multi-store installs.

Since this is so broken, let's just disable it. Product data is still sent as part of order and cart events. We have a future todo to make it possible to do a full batch product sync which will help this. We'll likely also come back around and see if there is a cleaner way to approach this problem.

My current idea for a future fix is to not sync disabled products and tell people to leave them disabled until they are done configuring them. Then fix syncing to sync all the associated simple products when a configurable product is saved or an individual associated product when the sumple product is saved.