### PR TITLE
use cypress-plugin-retries to be more resilient against fragile tests

### DIFF
--- a/devtools_m1/cypress/support/index.js
+++ b/devtools_m1/cypress/support/index.js
@@ -1,3 +1,4 @@
+require('cypress-plugin-retries')
 // ***********************************************************
 // This example support/index.js is processed and
 // loaded automatically before your test files.

--- a/devtools_m1/package-lock.json
+++ b/devtools_m1/package-lock.json
@@ -2031,6 +2031,12 @@
         "through": "^2.3.8"
       }
     },
+    "cypress-plugin-retries": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cypress-plugin-retries/-/cypress-plugin-retries-1.4.0.tgz",
+      "integrity": "sha512-Pudna9+dn0wp3flUVWt1ttn6hKTnD1MIBUSznYkw+uRv3JPNJhxHIv9cfxrZmig49/R1fIyGBVNORchtnFedEw==",
+      "dev": true
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",

--- a/devtools_m1/package.json
+++ b/devtools_m1/package.json
@@ -12,5 +12,8 @@
   },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": true
+  },
+  "devDependencies": {
+    "cypress-plugin-retries": "^1.4.0"
   }
 }

--- a/devtools_m1/tests.sh
+++ b/devtools_m1/tests.sh
@@ -2,5 +2,5 @@
 set -e
 
 DRIP_COMPOSE_ENV=test ./setup.sh
-$(npm bin)/cypress run --browser chrome #--record
+CYPRESS_RETRIES=2 $(npm bin)/cypress run --browser chrome #--record
 DRIP_COMPOSE_ENV=test ./docker_compose.sh down


### PR DESCRIPTION
CYPRESS_RETRIES=2 means a test will get run a maximum of 3 times before being considered failed.