### PR TITLE
Refactor isModuleActive helper

### DIFF
--- a/app/code/community/Drip/Connect/Block/Adminhtml/System/Config/Sync/Customers.php
+++ b/app/code/community/Drip/Connect/Block/Adminhtml/System/Config/Sync/Customers.php
@@ -57,11 +57,12 @@ class Drip_Connect_Block_Adminhtml_System_Config_Sync_Customers
      */
     public function isSyncAvailable()
     {
-        if (!Mage::helper('drip_connect')->isModuleActive()) {
+        $config = Drip_Connect_Model_Configuration::forCurrentStoreParam();
+        if (!$config->isEnabled()) {
             return false;
         }
 
-        $syncState = Drip_Connect_Model_Configuration::forCurrentStoreParam()->getCustomersSyncState();
+        $syncState = $config->getCustomersSyncState();
         if ($syncState != Drip_Connect_Model_Source_SyncState::READY &&
             $syncState != Drip_Connect_Model_Source_SyncState::READYERRORS) {
             return false;

--- a/app/code/community/Drip/Connect/Block/Adminhtml/System/Config/Sync/Orders.php
+++ b/app/code/community/Drip/Connect/Block/Adminhtml/System/Config/Sync/Orders.php
@@ -56,11 +56,12 @@ class Drip_Connect_Block_Adminhtml_System_Config_Sync_Orders
      */
     public function isSyncAvailable()
     {
-        if (!Mage::helper('drip_connect')->isModuleActive()) {
+        $config = Drip_Connect_Model_Configuration::forCurrentStoreParam();
+        if (!$config->isEnabled()) {
             return false;
         }
 
-        $syncState = Drip_Connect_Model_Configuration::forCurrentStoreParam()->getOrdersSyncState();
+        $syncState = $config->getOrdersSyncState();
         if ($syncState != Drip_Connect_Model_Source_SyncState::READY &&
             $syncState != Drip_Connect_Model_Source_SyncState::READYERRORS) {
             return false;

--- a/app/code/community/Drip/Connect/Helper/Data.php
+++ b/app/code/community/Drip/Connect/Helper/Data.php
@@ -8,23 +8,6 @@ class Drip_Connect_Helper_Data extends Mage_Core_Helper_Abstract
     const SALT = 'kjs5hds%$#zgf';
 
     /**
-     * check if module active
-     *
-     * @return bool
-     */
-    public function isModuleActive($store = null)
-    {
-        // TODO: Refactor this method away by using the config object at all the call sites.
-        if (empty($store)) {
-            $config = Drip_Connect_Model_Configuration::forCurrentStoreParam();
-        } else {
-            $config = new Drip_Connect_Model_Configuration($store);
-        }
-
-        return $config->isEnabled();
-    }
-
-    /**
      * prepare array of guest subscriber data
      *
      * @param Mage_Newsletter_Model_Subscriber $subscriber

--- a/app/code/community/Drip/Connect/Model/Observer/Base.php
+++ b/app/code/community/Drip/Connect/Model/Observer/Base.php
@@ -33,7 +33,8 @@ abstract class Drip_Connect_Model_Observer_Base
     }
 
     protected function isActive($observer) {
-        return Mage::helper('drip_connect')->isModuleActive();
+        $config = Drip_Connect_Model_Configuration::forCurrentScope();
+        return $config->isEnabled();
     }
 
     protected function getLogger()

--- a/app/code/community/Drip/Connect/Model/Observer/Customer/AdminBase.php
+++ b/app/code/community/Drip/Connect/Model/Observer/Customer/AdminBase.php
@@ -7,7 +7,8 @@ abstract class Drip_Connect_Model_Observer_Customer_AdminBase extends Drip_Conne
         $customer = $observer->getCustomer();
 
         $storeId = Mage::helper('drip_connect/customer')->getCustomerStoreId($customer);
+        $config = new Drip_Connect_Model_Configuration($storeId);
 
-        return Mage::helper('drip_connect')->isModuleActive($storeId);
+        return $config->isEnabled();
     }
 }

--- a/app/code/community/Drip/Connect/Model/Observer/Order/OrderBase.php
+++ b/app/code/community/Drip/Connect/Model/Observer/Order/OrderBase.php
@@ -9,6 +9,7 @@ abstract class Drip_Connect_Model_Observer_Order_OrderBase extends Drip_Connect_
             return false;
         }
 
-        return Mage::helper('drip_connect')->isModuleActive($order->getStoreId());
+        $config = new Drip_Connect_Model_Configuration($order->getStoreId());
+        return $config->isEnabled();
     }
 }

--- a/app/code/community/Drip/Connect/controllers/CartController.php
+++ b/app/code/community/Drip/Connect/controllers/CartController.php
@@ -7,7 +7,8 @@ class Drip_Connect_CartController extends Mage_Core_Controller_Front_Action
      */
     public function indexAction()
     {
-        if (! Mage::helper('drip_connect')->isModuleActive()) {
+        $config = Drip_Connect_Model_Configuration::forCurrentScope();
+        if (!$config->isEnabled()) {
             $this->norouteAction();
             return;
         }

--- a/app/design/frontend/base/default/template/drip/footer_js.phtml
+++ b/app/design/frontend/base/default/template/drip/footer_js.phtml
@@ -1,4 +1,4 @@
-<?php if (Mage::helper('drip_connect')->isModuleActive()) : ?>
+<?php if (Drip_Connect_Model_Configuration::forCurrentScope()->isEnabled()) : ?>
     <?php $accountId = Drip_Connect_Model_Configuration::forCurrentStoreParam()->getAccountId(); ?>
     <?php if (!empty($accountId)) : ?>
         <!-- Drip -->

--- a/app/design/frontend/base/default/template/drip/pdp_tracking.phtml
+++ b/app/design/frontend/base/default/template/drip/pdp_tracking.phtml
@@ -1,4 +1,4 @@
-<?php if (Mage::helper('drip_connect')->isModuleActive()) : ?>
+<?php if (Drip_Connect_Model_Configuration::forCurrentScope()->isEnabled()) : ?>
 <?php
     $product = Mage::registry('current_product');
     $currentPrice = Mage::helper('drip_connect')->priceAsCents($product->getFinalPrice());


### PR DESCRIPTION
Since the introduction of the config object, this helper is really only useful if we are depending on implicit scope. Let's explicitly define that scope and remove the helper.

Follows https://github.com/DripEmail/magento-m1-extension/pull/18