### PR TITLE
ECI-206 set occurred_at for cart events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Fix events creation for a person when a product is added or removed from the wish list.
 
+* Set occurred_at time for cart events based on time the relevant Quote was updated.
+
 ## 1.7.6
 
 * Fix logging on customer events.

--- a/app/code/community/Drip/Connect/Helper/Quote.php
+++ b/app/code/community/Drip/Connect/Helper/Quote.php
@@ -57,6 +57,7 @@ class Drip_Connect_Helper_Quote extends Mage_Core_Helper_Abstract
     {
         $data = $this->prepareQuoteData($quote);
         $data['action'] = Drip_Connect_Model_ApiCalls_Helper_CreateUpdateQuote::QUOTE_NEW;
+        $data['occurred_at'] = $quote->getUpdatedAt();
         if (!empty($data['items'])) {
             $apiCall = new Drip_Connect_Model_ApiCalls_Helper_CreateUpdateQuote($config, $data);
             $apiCall->call();
@@ -73,6 +74,7 @@ class Drip_Connect_Helper_Quote extends Mage_Core_Helper_Abstract
     {
         $data = $this->prepareQuoteData($quote);
         $data['action'] = Drip_Connect_Model_ApiCalls_Helper_CreateUpdateQuote::QUOTE_CHANGED;
+        $data['occurred_at'] = $quote->getUpdatedAt();
         $apiCall = new Drip_Connect_Model_ApiCalls_Helper_CreateUpdateQuote($config, $data);
         $apiCall->call();
     }

--- a/devtools_m1/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m1/cypress/integration/CustomerCartInteractions/steps.js
@@ -339,10 +339,19 @@ function basicOrderBodyAssertions(body) {
 Then('A simple order event should be sent to Drip', function() {
   cy.log('Validating that the order call has everything we need')
   cy.wrap(Mockclient.retrieveRecordedRequests({
-    'path': '/v3/123456/shopper_activity/order'
+    'path': '/v3/123456/shopper_activity/(order|cart)'
   })).then(function(recordedRequests) {
-    expect(recordedRequests).to.have.lengthOf(1)
-    const body = JSON.parse(recordedRequests[0].body.string)
+    expect(recordedRequests).to.have.lengthOf(2)
+    const orderRequests = recordedRequests.filter(function(req) {
+      return req.path === '/v3/123456/shopper_activity/order';
+    })
+    const cartRequests = recordedRequests.filter(function(req) {
+      return req.path === '/v3/123456/shopper_activity/cart';
+    })
+    expect(orderRequests).to.have.lengthOf(1)
+    const body = JSON.parse(orderRequests[0].body.string)
+    const cartBody = JSON.parse(cartRequests[0].body.string)
+    expect(body.occurred_at).to.be.greaterThan(cartBody.occurred_at)
     expect(body.action).to.eq('placed')
     expect(body.email).to.eq('testuser@example.com')
     expect(body.grand_total).to.eq(16.22)


### PR DESCRIPTION
Addresses: [ECI-206](https://dripcom.atlassian.net/browse/ECI-206)

This may also fix [ECI-189](https://dripcom.atlassian.net/browse/ECI-189)

We already set `occurred_at` on order events. That is at least part of why we are seeing cart events coming in after orders on subscriber timelines. Order events are set to the original order's `updated_at` time in Magento, but cart events are set by API Gateway to the received_at time.