### PR TITLE
format cart dates

### DIFF
--- a/app/code/community/Drip/Connect/Helper/Quote.php
+++ b/app/code/community/Drip/Connect/Helper/Quote.php
@@ -57,7 +57,7 @@ class Drip_Connect_Helper_Quote extends Mage_Core_Helper_Abstract
     {
         $data = $this->prepareQuoteData($quote);
         $data['action'] = Drip_Connect_Model_ApiCalls_Helper_CreateUpdateQuote::QUOTE_NEW;
-        $data['occurred_at'] = $quote->getUpdatedAt();
+        $data['occurred_at'] = (string) Mage::helper('drip_connect')->formatDate($quote->getUpdatedAt());
         if (!empty($data['items'])) {
             $apiCall = new Drip_Connect_Model_ApiCalls_Helper_CreateUpdateQuote($config, $data);
             $apiCall->call();
@@ -74,7 +74,7 @@ class Drip_Connect_Helper_Quote extends Mage_Core_Helper_Abstract
     {
         $data = $this->prepareQuoteData($quote);
         $data['action'] = Drip_Connect_Model_ApiCalls_Helper_CreateUpdateQuote::QUOTE_CHANGED;
-        $data['occurred_at'] = $quote->getUpdatedAt();
+        $data['occurred_at'] = (string) Mage::helper('drip_connect')->formatDate($quote->getUpdatedAt());
         $apiCall = new Drip_Connect_Model_ApiCalls_Helper_CreateUpdateQuote($config, $data);
         $apiCall->call();
     }

--- a/devtools_m1/cypress/integration/CustomerCartInteractions.feature
+++ b/devtools_m1/cypress/integration/CustomerCartInteractions.feature
@@ -101,5 +101,7 @@ Feature: Customer Cart Interactions
     When I open the 'main' homepage
       And I logout
       And I add a 'simple' widget to my cart
-      And I check out as a guest
+    When I begin check out as a guest
+    Then A simple cart event should be sent to Drip
+    When I complete check out as a guest
     Then A simple order event should be sent to Drip

--- a/devtools_m1/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m1/cypress/integration/CustomerCartInteractions/steps.js
@@ -304,7 +304,7 @@ When('I check out', function() {
   cy.contains('Your order has been received')
 })
 
-When('I check out as a guest', function() {
+When('I begin check out as a guest', function() {
   cy.log('Resetting mocks')
   cy.wrap(Mockclient.reset())
 
@@ -322,8 +322,13 @@ When('I check out as a guest', function() {
   cy.get('input[name="billing[telephone]"]').type('999-999-9999')
   cy.get('input[id="billing:use_for_shipping_yes"]').check()
   cy.get('button[onclick="billing.save()"]').click()
-
   cy.contains('Flat Rate')
+})
+
+When('I complete check out as a guest', function() {
+  cy.log('Resetting mocks')
+  cy.wrap(Mockclient.reset())
+
   cy.get('#shipping-method-buttons-container').contains('Continue').click()
 
   cy.contains('Check / Money order')

--- a/devtools_m1/cypress/integration/CustomerCartInteractions/steps.js
+++ b/devtools_m1/cypress/integration/CustomerCartInteractions/steps.js
@@ -84,6 +84,7 @@ Then('A simple cart event should be sent to Drip', function() {
     expect(body.provider).to.eq('magento')
     expect(body.total_discounts).to.eq(0)
     expect(body.version).to.match(/^Magento 1\.9\.4\.2, Drip Extension \d+\.\d+\.\d+$/)
+    expect(body.occurred_at).to.match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
     expect(body.items).to.have.lengthOf(1)
 
     const item = body.items[0]


### PR DESCRIPTION
When working on the M2 port of https://github.com/DripEmail/magento-m1-extension/pull/28 to set `occurred_at` for carts, I realized I'd neglected to properly format the date.