### PR TITLE
ECI-14 customer identify tests

### DIFF
--- a/devtools_m1/cypress/integration/CustomerIdentify.feature
+++ b/devtools_m1/cypress/integration/CustomerIdentify.feature
@@ -1,0 +1,11 @@
+Feature: Customer Identification
+
+  I want to identify customers when they enter their email address
+
+  Scenario: When a site has Client.js enabled
+    Given I am logged into the admin interface
+      And I have set up a multi-store configuration
+      And I have configured Drip to be enabled for 'site1_website'
+    When I open the 'site1' homepage
+      And I create an account
+    Then an identify call is made to Drip

--- a/devtools_m1/cypress/integration/CustomerIdentify/steps.js
+++ b/devtools_m1/cypress/integration/CustomerIdentify/steps.js
@@ -1,0 +1,26 @@
+import { Given, When, Then } from "cypress-cucumber-preprocessor/steps"
+import { mockServerClient } from "mockserver-client"
+
+const Mockclient = mockServerClient("localhost", 1080);
+
+When('I create an account', function() {
+  cy.contains('Register').click({ force: true })
+  cy.get('#form-validate').within(function() {
+    cy.get('input[name="firstname"]').type('Test')
+    cy.get('input[name="lastname"]').type('User')
+    cy.get('input[name="email"]').type('testuser@example.com')
+    cy.get('input[name="password"]').type('blahblah123!!!')
+    cy.get('input[name="confirmation"]').type('blahblah123!!!')
+    cy.contains('Register').click()
+  })
+})
+
+Then('an identify call is made to Drip', function() {
+  cy.log('Validating that an identify call was made')
+  cy.get('script').then((scriptTags) => {
+    const identifyTags = scriptTags.toArray().filter(function(tag) {
+      return tag.src.match(/https:\/\/api.getdrip.com\/client\/identify\?time_zone=[a-zA-Z0-9_%]+&visitor_uuid=\w+&email=testuser%40example.com&drip_account_id=123456&callback=/)
+    })
+    expect(identifyTags).to.not.be.empty
+  })
+})


### PR DESCRIPTION
Drip's `client.js` automatically sends an identify call when an email address is entered into a form. This PR adds a test to confirm that we make an identify call when a customer signs in.