### PR TITLE
Introduce a mutex to avoid an infinite loop ECI-204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Set occurred_at time for cart events based on time the relevant Quote was updated.
 * When a configurable product has children than are not visible individually, use the parent's url and image_url.
 * Only allow setting the memory limit override globally
+* Wrap `BeforeQuoteSaved` and `AfterQuoteSaved` in a mutex to avoid an infinite loop condition triggered by OneStepCheckout.
 
 ## 1.7.6
 

--- a/app/code/community/Drip/Connect/Model/Observer/Quote/AfterQuoteSaved.php
+++ b/app/code/community/Drip/Connect/Model/Observer/Quote/AfterQuoteSaved.php
@@ -12,6 +12,12 @@ class Drip_Connect_Model_Observer_Quote_AfterQuoteSaved extends Drip_Connect_Mod
             return;
         }
 
+        $mutex = new Drip_Connect_Model_RegistryMutex(Drip_Connect_Model_RegistryMutex::QUOTE_OBSERVER_MUTEX_KEY);
+        // Make sure we aren't currently processing a beforeQuoteSaved observer due to a loop.
+        if (!$mutex->checkAvailable()) {
+            return;
+        }
+
         $quote = $observer->getEvent()->getQuote();
 
         if (Mage::helper('drip_connect/quote')->isUnknownUser($quote)) {

--- a/app/code/community/Drip/Connect/Model/RegistryMutex.php
+++ b/app/code/community/Drip/Connect/Model/RegistryMutex.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * A simple mutex using the Magento registry.
+ *
+ * This is obviously very not thread-safe and is intended to be used in the
+ * context of an observer.
+ */
+class Drip_Connect_Model_RegistryMutex
+{
+    // A couple of defined mutexes.
+    const QUOTE_OBSERVER_MUTEX_KEY = 'dripquoteobservermutex';
+
+    /**
+     * @var string The registry key.
+     */
+    protected $key;
+
+    public function __construct($key)
+    {
+        $this->key = $key;
+    }
+
+    /**
+     * Check whether the mutex is set and obtain it if not.
+     *
+     * @return bool Whether we have successfully obtained the lock.
+     */
+    public function checkAndSet()
+    {
+        $res = $this->checkAvailable();
+        if ($res) {
+            Mage::register($this->key, 'obtained');
+        }
+        return $res;
+    }
+
+    /**
+     * Check whether the mutex is set.
+     *
+     * @return bool True if the lock is available.
+     */
+    public function checkAvailable()
+    {
+        return Mage::registry($this->key) === null;
+    }
+
+    /**
+     * Release the mutex lock.
+     */
+    public function release()
+    {
+        Mage::unregister($this->key);
+    }
+}


### PR DESCRIPTION
Hopefully fixes https://github.com/DripEmail/magento-m1-extension/issues/34 and ECI-204.

We can have an infinite loop in Magento because on Quote load, the totals are collected and saved. OneStepCheckout triggers this behavior for some reason.

We wrap a mutex around the before quote save observer, causing both the before and after observers to not trigger an infinite loop.